### PR TITLE
Remove platform path separator from name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,8 @@ const debug = createDebug('devcert');
 export default async function devcert(appName: string, options: { installCertutil?: boolean } = {}) {
   debug(`development cert requested for ${ appName }`);
 
+  appName = appName.replace(new RegExp(path.sep, 'g'), '')
+
   if (!isMac && !isLinux && !isWindows) {
     throw new Error(`devcert: "${ process.platform }" platform not supported`);
   }


### PR DESCRIPTION
This allows users to supply a name with a path separator for the platform
but still just have "things work"