### PR TITLE
Truncate name to 64 characters

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,10 @@ const debug = createDebug('devcert');
 export default async function devcert(appName: string, options: { installCertutil?: boolean } = {}) {
   debug(`development cert requested for ${ appName }`);
 
+  if (appName.length > 64) {
+    appName = appName.slice(-64)
+  }
+
   if (!isMac && !isLinux && !isWindows) {
     throw new Error(`devcert: "${ process.platform }" platform not supported`);
   }


### PR DESCRIPTION
Use last 64 characters for significant bits, as our use-case is paths, and
they're more specific as they get longer...