### PR TITLE
add `subjectAltName` to server certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ app.get('/', function (req, res) {
   res.send('Hello Secure World!');
 });
 
-getDevelopmentCertificate('my-app', { installCertutil: true }).then((ssl) => {
+getDevelopmentCertificate('localhost', { installCertutil: true }).then((ssl) => {
   https.createServer(ssl, app).listen(3000);
 });
 ```
@@ -27,7 +27,9 @@ Now open https://localhost:3000 and voila - your page loads with no scary
 warnings or hoops to jump through.
 
 > Certificates are cached by name, so two calls for
-`getDevelopmentCertificate('foo')` will return the same key and certificate.
+`getDevelopmentCertificate('foo')` will return the same key and certificate. The
+first argument to `getDevelopmentCertificate` is used as the common name so that
+the certificate can be accessed by `https://foo` as well as `https://localhost`.
 
 ### installCertutil option
 

--- a/openssl.conf
+++ b/openssl.conf
@@ -42,8 +42,19 @@ keyUsage = critical, digitalSignature, cRLSign, keyCertSign
 # Extensions for server certificates (`man x509v3_config`).
 basicConstraints = CA:FALSE
 nsCertType = server
-nsComment = "OpenSSL Generated Server Certificate"
+nsComment = "DevCert Issued Certificate"
 subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid,issuer:always
 keyUsage = critical, digitalSignature, keyEncipherment
 extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+
+[ alt_names ]
+DNS.1 = ${ENV::SAN}
+DNS.2 = localhost
+DNS.3 = localhost.localdomain
+DNS.4 = lvh.me
+DNS.5 = *.lvh.me
+DNS.6 = [::1]
+IP.1 = 127.0.0.1
+IP.2 = fe80::1

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,7 +13,8 @@ export function openssl(cmd: string) {
   return run(`openssl ${ cmd }`, {
     stdio: 'ignore',
     env: Object.assign({
-      RANDFILE: path.join(configPath('.rnd'))
+      RANDFILE: path.join(configPath('.rnd')),
+      SAN: "localhost"
     }, process.env)
   });
 }


### PR DESCRIPTION
similar to https://github.com/davewasmer/devcert/pull/2, but allows the user to specify includes other common `subjectAltName` entries, along with `appName` parameter passed when creating the cert (also renamed the parameter to `commonName`)