### PR TITLE
Add Types to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.3.2",
   "description": "Generate trusted local SSL/TLS certificates for local SSL development",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "test": "echo \"Ha.\" && exit 1",
     "prepublish": "tsc"


### PR DESCRIPTION
This PR is to add a reference to the exposed types that are generated by TypeScript.  By adding this reference other devs using typescript would be able to rely on your package without needing to add their own type definitions for the exposed methods.