### PR TITLE
Fix check to see if nss is brew installed

### DIFF
--- a/src/platforms/darwin.ts
+++ b/src/platforms/darwin.ts
@@ -82,7 +82,7 @@ export default class MacOSPlatform implements Platform {
 
   private isNSSInstalled() {
     try {
-      return /^nss$/m.test(run('brew list').toString())
+      return /^nss(@.+)?$/m.test(run('brew list').toString())
     } catch (e) {
       return false;
     }

--- a/src/platforms/darwin.ts
+++ b/src/platforms/darwin.ts
@@ -82,7 +82,7 @@ export default class MacOSPlatform implements Platform {
 
   private isNSSInstalled() {
     try {
-      return run('brew list').toString().indexOf('nss') > -1;
+      return /^nss$/m.test(run('brew list').toString())
     } catch (e) {
       return false;
     }


### PR DESCRIPTION
Previously the check would return true if `nss` was found in any part of the retuned list of brew installed executables. This meant that when a tool like `openssl` was installed the `nss` check would incorrectly pass. This fix looks explicitly for a line which contains `nss` with optional version.

One other small point. The README mentions `skipCertutil` as an option, but the code seems to be looking for `skipCertutilInstall`. I didn't fix up as not sure which you'd like to go with.