### PR TITLE
Update command-exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/rimraf": "^2.0.2",
     "@types/tmp": "^0.0.33",
     "application-config-path": "^0.1.0",
-    "command-exists": "^1.2.2",
+    "command-exists": "^1.2.4",
     "configstore": "^3.0.0",
     "debug": "^3.1.0",
     "eol": "^0.9.1",


### PR DESCRIPTION
Versions before 1.2.4 of command-exists are vulnerable to command injection (critical). https://nodesecurity.io/advisories/659