### PR TITLE
Fix issues related to Firefox on Windows and redirecting

### DIFF
--- a/src/platforms/win32.ts
+++ b/src/platforms/win32.ts
@@ -37,7 +37,11 @@ export default class WindowsPlatform implements Platform {
     }
     debug('adding devcert root to Firefox trust store')
     // Firefox (don't even try NSS certutil, no easy install for Windows)
-    await openCertificateInFirefox('start firefox', certificatePath);
+    try {
+      await openCertificateInFirefox('start firefox', certificatePath);
+    } catch {
+      debug('Error opening Firefox, most likely Firefox is not installed');
+    }
   }
 
   async addDomainToHostFileIfMissing(domain: string) {

--- a/src/user-interface.ts
+++ b/src/user-interface.ts
@@ -50,7 +50,7 @@ const DefaultUI: UserInterface = {
     return `
       <html>
         <head>
-          <meta http-equiv="refresh" content="0; url="${certificateURL}" />
+          <meta http-equiv="refresh" content="0; url=${certificateURL}" />
         </head>
       </html>
     `;


### PR DESCRIPTION
Fixes two issues related to Firefox, one on Windows and one in general.

On Windows if the user did not have Firefox installed it would throw an exception when it attempted to open it to show a certificate. I'm swallowing that exception and debug logging that we hit an issue with it.

The second issue appeared that once Firefox launched it wasn't properly redirecting to the /certificate endpoint of the URL. This appears to be done to a malformed URL in the redirect. 