### PR TITLE
Extend the CA cert to last for 7000 days

### DIFF
--- a/src/certificate-authority.ts
+++ b/src/certificate-authority.ts
@@ -44,7 +44,7 @@ export default async function installCertificateAuthority(options: Options = {})
   generateKey(rootKeyPath);
 
   debug(`Generating a CA certificate`);
-  openssl(`req -new -x509 -config "${ caSelfSignConfig }" -key "${ rootKeyPath }" -out "${ rootCertPath }"`);
+  openssl(`req -new -x509 -config "${ caSelfSignConfig }" -key "${ rootKeyPath }" -out "${ rootCertPath }" -days 7000`);
 
   debug('Saving certificate authority credentials');
   await saveCertificateAuthorityCredentials(rootKeyPath, rootCertPath);


### PR DESCRIPTION
It appears for some reason that the `default_days` value in the config file for the CA is not being respected. This forces from the command line the CA cert to last 7000 days. I believe this resolves the issues seen in #22. I couldn't find any documentation as to why this changed or if it was changed intentionally by OpenSSL or something else.