### PR TITLE
Fix false positive NSS install check

### DIFF
--- a/src/platforms/darwin.ts
+++ b/src/platforms/darwin.ts
@@ -82,7 +82,7 @@ export default class MacOSPlatform implements Platform {
 
   private isNSSInstalled() {
     try {
-      return run('brew list').toString().indexOf('nss') > -1;
+      return run('brew list').toString().split('\n').indexOf('nss') > -1;
     } catch (e) {
       return false;
     }

--- a/src/platforms/darwin.ts
+++ b/src/platforms/darwin.ts
@@ -82,7 +82,7 @@ export default class MacOSPlatform implements Platform {
 
   private isNSSInstalled() {
     try {
-      return run('brew list').toString().split('\n').indexOf('nss') > -1;
+      return run('brew list -1').toString().includes('\nnss\n');
     } catch (e) {
       return false;
     }


### PR DESCRIPTION
The current code checks if NSS is installed on the Mac with a string search for "nss" in the output of `brew list`. Unfortunately, that means that the string `openssl` also matches, causing it to falsely assume that certutil is installed. This PR splits the output into a array, which it searches for the exact value "nss", meaning that partial matches such as "openssl" no longer happen.