### PR TITLE
feat(subject_alt_names): Allow multiple subject_alt_names

### DIFF
--- a/openssl-configurations/domain-certificate-signing-requests.conf
+++ b/openssl-configurations/domain-certificate-signing-requests.conf
@@ -21,5 +21,4 @@ subjectAltName = @subject_alt_names
 subjectKeyIdentifier = hash
 
 [ subject_alt_names ]
-DNS.1 = *.<%= domain %>
-DNS.2 = <%= domain %>
+<%= altNames %>

--- a/openssl-configurations/domain-certificates.conf
+++ b/openssl-configurations/domain-certificates.conf
@@ -35,5 +35,4 @@ extendedKeyUsage = serverAuth
 subjectAltName = @subject_alt_names
 
 [ subject_alt_names ]
-DNS.1 = *.<%= domain %>
-DNS.2 = <%= domain %>
+<%= altNames %>


### PR DESCRIPTION
Related to: https://github.com/davewasmer/devcert/issues/33 allows a user to pass in multiple domain names for one certificate without introducing breaking API changes.