### PR TITLE
Append to the host file on Win32

### DIFF
--- a/src/platforms/win32.ts
+++ b/src/platforms/win32.ts
@@ -47,7 +47,7 @@ export default class WindowsPlatform implements Platform {
   async addDomainToHostFileIfMissing(domain: string) {
     let hostsFileContents = read(this.HOST_FILE_PATH, 'utf8');
     if (!hostsFileContents.includes(domain)) {
-      await sudo(`echo 127.0.0.1  ${ domain } > ${ this.HOST_FILE_PATH }`);
+      await sudo(`echo 127.0.0.1  ${ domain } >> ${ this.HOST_FILE_PATH }`);
     }
   }
 


### PR DESCRIPTION
Currently devcert will create a new host file on windows rather then appending to the existing host file.