### PR TITLE
Improve checking entries in the hostfile

### DIFF
--- a/src/platforms/darwin.ts
+++ b/src/platforms/darwin.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import { writeFileSync as writeFile, existsSync as exists, readFileSync as read } from 'fs';
 import createDebug from 'debug';
 import { sync as commandExists } from 'command-exists';
-import { run } from '../utils';
+import { isDomainInHostFile, run } from '../utils';
 import { Options } from '../index';
 import { addCertificateToNSSCertDB, openCertificateInFirefox, closeFirefox } from './shared';
 import { Platform } from '.';
@@ -58,7 +58,7 @@ export default class MacOSPlatform implements Platform {
 
   async addDomainToHostFileIfMissing(domain: string) {
     let hostsFileContents = read(this.HOST_FILE_PATH, 'utf8');
-    if (!hostsFileContents.includes(domain)) {
+    if (!isDomainInHostFile(hostsFileContents, domain)) {
       run(`echo '\n127.0.0.1 ${ domain }' | sudo tee -a "${ this.HOST_FILE_PATH }" > /dev/null`);
     }
   }

--- a/src/platforms/linux.ts
+++ b/src/platforms/linux.ts
@@ -3,7 +3,7 @@ import { existsSync as exists, readFileSync as read, writeFileSync as writeFile 
 import createDebug from 'debug';
 import { sync as commandExists } from 'command-exists';
 import { addCertificateToNSSCertDB, openCertificateInFirefox, closeFirefox } from './shared';
-import { run } from '../utils';
+import { isDomainInHostFile, run } from '../utils';
 import { Options } from '../index';
 import UI from '../user-interface';
 import { Platform } from '.';
@@ -70,7 +70,7 @@ export default class LinuxPlatform implements Platform {
 
   async addDomainToHostFileIfMissing(domain: string) {
     let hostsFileContents = read(this.HOST_FILE_PATH, 'utf8');
-    if (!hostsFileContents.includes(domain)) {
+    if (!isDomainInHostFile(hostsFileContents, domain)) {
       run(`echo '127.0.0.1  ${ domain }' | sudo tee -a "${ this.HOST_FILE_PATH }" > /dev/null`);
     }
   }

--- a/src/platforms/win32.ts
+++ b/src/platforms/win32.ts
@@ -4,7 +4,7 @@ import { writeFileSync as write, readFileSync as read } from 'fs';
 import { Options } from '../index';
 import { openCertificateInFirefox } from './shared';
 import { Platform } from '.';
-import { run, sudo } from '../utils';
+import { isDomainInHostFile, run, sudo,  } from '../utils';
 import UI from '../user-interface';
 
 const debug = createDebug('devcert:platforms:windows');
@@ -46,7 +46,7 @@ export default class WindowsPlatform implements Platform {
 
   async addDomainToHostFileIfMissing(domain: string) {
     let hostsFileContents = read(this.HOST_FILE_PATH, 'utf8');
-    if (!hostsFileContents.includes(domain)) {
+    if (!isDomainInHostFile(hostsFileContents, domain)) {
       await sudo(`echo 127.0.0.1  ${ domain } > ${ this.HOST_FILE_PATH }`);
     }
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,3 +49,13 @@ export function sudo(cmd: string): Promise<string | null> {
     });
   });
 }
+
+export function isDomainInHostFile(hostFileContents: string, domain: string): boolean {
+  // Do a check for a full match since a string includes can be fooled by 
+  // a subdomain being present in the host file.
+  const isPresent = hostFileContents
+    .replace(/\s+/g, " ")
+    .split(" ")
+    .filter(item => item === domain).length > 0;
+ return isPresent;
+}


### PR DESCRIPTION
Currently the host file check will not add a domain if a subdomain of that domain already exists.

For example if the host file contains `127.0.0.1  sub.example.com` and the user is setting up `example.com` it will be skipped and not added to the hostfile.