### PR TITLE
(feature) Return CA Certificate path/data

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/davewasmer/devcert#readme",
   "devDependencies": {
     "standard-version": "^4.3.0",
-    "typescript": "^2.7.0"
+    "typescript": "^2.9.2"
   },
   "dependencies": {
     "@types/configstore": "^2.1.1",
@@ -52,7 +52,7 @@
     "rimraf": "^2.6.2",
     "sudo-prompt": "^8.2.0",
     "tmp": "^0.0.33",
-    "tslib": "^1.8.1"
+    "tslib": "^1.10.0"
   },
   "optionalDependencies": {}
 }

--- a/src/certificate-authority.ts
+++ b/src/certificate-authority.ts
@@ -43,7 +43,7 @@ export default async function installCertificateAuthority(options: Options = {})
   generateKey(rootKeyPath);
 
   debug(`Generating a CA certificate`);
-  openssl(`req -new -x509 -config "${caSelfSignConfig}" -key "${rootKeyPath}" -out "${rootCACertPath}" -days 7000`);
+  openssl(`req -new -x509 -config "${ caSelfSignConfig }" -key "${ rootKeyPath }" -out "${ rootCACertPath }" -days 7000`);
 
   debug('Saving certificate authority credentials');
   await saveCertificateAuthorityCredentials(rootKeyPath);
@@ -70,7 +70,7 @@ function scrubOldInsecureVersions() {
   }
 
   // Delete the root certificate keys, as well as the generated app certificates
-  debug(`Checking ${configDir} for legacy files ...`);
+  debug(`Checking ${ configDir } for legacy files ...`);
   [
     path.join(configDir, 'openssl.conf'),
     path.join(configDir, 'devcert-ca-root.key'),
@@ -79,7 +79,7 @@ function scrubOldInsecureVersions() {
     path.join(configDir, 'certs')
   ].forEach((filepath) => {
     if (exists(filepath)) {
-      debug(`Removing legacy file: ${filepath}`)
+      debug(`Removing legacy file: ${ filepath }`)
       rimraf(filepath);
     }
   });

--- a/src/certificate-authority.ts
+++ b/src/certificate-authority.ts
@@ -35,7 +35,6 @@ export default async function installCertificateAuthority(options: Options = {})
 
   debug(`Generating a root certificate authority`);
   let rootKeyPath = mktmp();
-  let rootCertPath = mktmp();
 
   debug(`Generating the OpenSSL configuration needed to setup the certificate authority`);
   seedConfigFiles();
@@ -44,13 +43,13 @@ export default async function installCertificateAuthority(options: Options = {})
   generateKey(rootKeyPath);
 
   debug(`Generating a CA certificate`);
-  openssl(`req -new -x509 -config "${ caSelfSignConfig }" -key "${ rootKeyPath }" -out "${ rootCertPath }" -days 7000`);
+  openssl(`req -new -x509 -config "${caSelfSignConfig}" -key "${rootKeyPath}" -out "${rootCACertPath}" -days 7000`);
 
   debug('Saving certificate authority credentials');
-  await saveCertificateAuthorityCredentials(rootKeyPath, rootCertPath);
+  await saveCertificateAuthorityCredentials(rootKeyPath);
 
   debug(`Adding the root certificate authority to trust stores`);
-  await currentPlatform.addToTrustStores(rootCertPath, options);
+  await currentPlatform.addToTrustStores(rootCACertPath, options);
 }
 
 /**
@@ -71,7 +70,7 @@ function scrubOldInsecureVersions() {
   }
 
   // Delete the root certificate keys, as well as the generated app certificates
-  debug(`Checking ${ configDir } for legacy files ...`);
+  debug(`Checking ${configDir} for legacy files ...`);
   [
     path.join(configDir, 'openssl.conf'),
     path.join(configDir, 'devcert-ca-root.key'),
@@ -80,7 +79,7 @@ function scrubOldInsecureVersions() {
     path.join(configDir, 'certs')
   ].forEach((filepath) => {
     if (exists(filepath)) {
-      debug(`Removing legacy file: ${ filepath }`)
+      debug(`Removing legacy file: ${filepath}`)
       rimraf(filepath);
     }
   });
@@ -101,20 +100,14 @@ function seedConfigFiles() {
 export async function withCertificateAuthorityCredentials(cb: ({ caKeyPath, caCertPath }: { caKeyPath: string, caCertPath: string }) => Promise<void> | void) {
   debug(`Retrieving devcert's certificate authority credentials`);
   let tmpCAKeyPath = mktmp();
-  let tmpCACertPath = mktmp();
   let caKey = await currentPlatform.readProtectedFile(rootCAKeyPath);
-  let caCert = await currentPlatform.readProtectedFile(rootCACertPath);
   writeFile(tmpCAKeyPath, caKey);
-  writeFile(tmpCACertPath, caCert);
-  await cb({ caKeyPath: tmpCAKeyPath, caCertPath: tmpCACertPath });
+  await cb({ caKeyPath: tmpCAKeyPath, caCertPath: rootCACertPath });
   rm(tmpCAKeyPath);
-  rm(tmpCACertPath);
 }
 
-async function saveCertificateAuthorityCredentials(keypath: string, certpath: string) {
+async function saveCertificateAuthorityCredentials(keypath: string) {
   debug(`Saving devcert's certificate authority credentials`);
   let key = readFile(keypath, 'utf-8');
-  let cert = readFile(certpath, 'utf-8');
   await currentPlatform.writeProtectedFile(rootCAKeyPath, key);
-  await currentPlatform.writeProtectedFile(rootCACertPath, cert);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,14 +41,14 @@ export interface Options {
  * If `returnCa` is `read`, include Buffer with contents of CA cert in return value.
  */
 export async function certificateFor(domain: string, options: Options = {}) {
-  debug(`Certificate requested for ${domain}. Skipping certutil install: ${Boolean(options.skipCertutilInstall)}. Skipping hosts file: ${Boolean(options.skipHostsFile)}`);
+  debug(`Certificate requested for ${ domain }. Skipping certutil install: ${ Boolean(options.skipCertutilInstall) }. Skipping hosts file: ${ Boolean(options.skipHostsFile) }`);
 
   if (options.ui) {
     Object.assign(UI, options.ui);
   }
 
   if (!isMac && !isLinux && !isWindows) {
-    throw new Error(`Platform not supported: "${process.platform}"`);
+    throw new Error(`Platform not supported: "${ process.platform }"`);
   }
 
   if (!commandExists('openssl')) {
@@ -64,7 +64,7 @@ export async function certificateFor(domain: string, options: Options = {}) {
   }
 
   if (!exists(pathForDomain(domain, `certificate.crt`))) {
-    debug(`Can't find certificate file for ${domain}, so it must be the first request for ${domain}. Generating and caching ...`);
+    debug(`Can't find certificate file for ${ domain }, so it must be the first request for ${ domain }. Generating and caching ...`);
     await generateDomainCertificate(domain);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,8 @@ export async function certificateFor(domain: string, options: Options = {}) {
   debug(`Returning domain certificate`);
   if (options.returnCa) {
     return {
-      ca: options.returnCa === 'read' ? readFile(rootCACertPath) : rootCACertPath,
+      ca: options.getCaBuffer && readFile(rootCACertPath),
+      caPath: options.getCaPath && rootCACertPath,
       key: readFile(domainKeyPath),
       cert: readFile(domainCertPath)
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,11 +18,16 @@ import UI, { UserInterface } from './user-interface';
 
 const debug = createDebug('devcert');
 
-export interface Options {
-  getCaPath?: boolean,
-  getCaBuffer?: boolean,
-  skipCertutilInstall?: true,
-  skipHostsFile?: true,
+export interface Options /* extends Partial<ICaBufferOpts & ICaPathOpts>  */{
+  /** Return the CA certificate data? */
+  getCaBuffer?: boolean;
+  /** Return the path to the CA certificate? */
+  getCaPath?: boolean;
+  /** If `certutil` is not installed already (for updating nss databases; e.g. firefox), do not attempt to install it */
+  skipCertutilInstall?: boolean,
+  /** Do not update your systems host file with the domain name of the certificate */
+  skipHostsFile?: boolean,
+  /** User interface hooks */
   ui?: UserInterface
 }
 
@@ -37,9 +42,6 @@ export interface Options {
  * Returns a promise that resolves with { key, cert }, where `key` and `cert`
  * are Buffers with the contents of the certificate private key and certificate
  * file, respectively
- * 
- * If `returnCa` is `true`, include path to CA cert as `ca` in return value.
- * If `returnCa` is `read`, include Buffer with contents of CA cert in return value.
  */
 export async function certificateFor(domain: string, options: Options = {}) {
   debug(`Certificate requested for ${ domain }. Skipping certutil install: ${ Boolean(options.skipCertutilInstall) }. Skipping hosts file: ${ Boolean(options.skipHostsFile) }`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,12 @@ type IReturnData<O extends Options = {}> = (IDomainData) & (IReturnCa<O>) & (IRe
  * Returns a promise that resolves with { key, cert }, where `key` and `cert`
  * are Buffers with the contents of the certificate private key and certificate
  * file, respectively
+ * 
+ * If `options.getCaBuffer` is true, return value will include the ca certificate data
+ * as { ca: Buffer }
+ * 
+ * If `options.getCaPath` is true, return value will include the ca certificate path
+ * as { caPath: string }
  */
 export async function certificateFor<O extends Options>(domain: string, options: O = {} as O): Promise<IReturnData<O>> {
   debug(`Certificate requested for ${ domain }. Skipping certutil install: ${ Boolean(options.skipCertutilInstall) }. Skipping hosts file: ${ Boolean(options.skipHostsFile) }`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,8 @@ import UI, { UserInterface } from './user-interface';
 const debug = createDebug('devcert');
 
 export interface Options {
-  returnCa?: true | 'read',
+  getCaPath?: boolean,
+  getCaBuffer?: boolean,
   skipCertutilInstall?: true,
   skipHostsFile?: true,
   ui?: UserInterface

--- a/yarn.lock
+++ b/yarn.lock
@@ -1231,17 +1231,19 @@ trim-off-newlines@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz#9f9ba9d9efa8764c387698bcbfeb2c848f11adb3"
 
-tslib@^1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.8.1.tgz#6946af2d1d651a7b1863b531d6e5afa41aa44eac"
+tslib@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
+  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.7.0:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
+typescript@^2.9.2:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
+  integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
 
 uglify-js@^2.6:
   version "2.8.18"


### PR DESCRIPTION
This PR changes three things:

- Updates typescript  & eslint to fix runtime errors.
- Relax excessive security of CA certificate
    - The certificate needs to be read by browsers and other applications in order to trust certificates that are issued by it.  If it is in a trust store, in the browser or in the system, the certificate can be read.  It doesn't need to be encrypted/locked down on the disk.
    - Only the key really needs to be locked down
    - Being able to read the certificate without requiring a password provides a better user experience when using this new feature.  Means you don't have to enter a password every single time you start your dev server.
- Allows user to define `returnCa` option to receive the CA certificate path or data (as a buffer)

> This doesn't introduce any breaking API changes.  If nobody uses the option, they will continue to get the same data they always have.

The reason for this new feature is because node likes to throw errors when trying to fetch from a site that is using a self-signed (or private CA signed) certificate, since it maintains its own trust store.  There are a couple of methods to fix this, which I will detail below, but in order to use them, the CA certificate **_must_** be readable.  It just made sense to perform the read/return the path internally, since `devcert` already knows where everything is, instead of making the user do it.

The error that is occurring is `unable to verify the first certificate` .  In order to fix that, you have to add the CA to node's trusted store, or completely bypass by telling node not to reject unauthorized certificates (insecure).   

You can:
- Use an environment variable
```sh
NODE_EXTRA_CA_CERTS=/path/to/ca/cert.crt node ...
```

- Set the environment variable in code
```js
process.env.NODE_EXTRA_CA_CERTS = '/path/to/ca/cert.crt';
```

- Or, you can manually add it to your https global ca options
```js
const https = require('https');
https.globalAgent.options.ca || https.globalAgent.options.ca = [];
https.globalAgent.options.ca.push(caData);
```

The issue with the last method is it replaces all of the predefined certs as well.  Preferred method would be number 2, because node then reads and appends that cert to its trust store when it starts the server.

This is why we need to be able to retrieve the path to the CA cert, or the CA cert data itself.
How I achieve this on the receiving end is like this:
```js
const sslData = await certificateFor('project-name', { returnCa: true });
if (sslData.ca) process.env.NODE_EXTRA_CA_CERTS = sslData.ca;
const ssl = {
   cert: sslData.cert,
   key: sslData.key,
}
const server = require('https').createServer(ssl, app);
```

It's destructured like that so that the `ca` parameter isn't passed to `https`, because that indicates peer authentication.

## Related
Issue gatsbyjs/gatsby#14990