### PR TITLE
Reorder SAN for firefox trust

### DIFF
--- a/openssl-configurations/domain-certificate-signing-requests.conf
+++ b/openssl-configurations/domain-certificate-signing-requests.conf
@@ -21,5 +21,5 @@ subjectAltName = @subject_alt_names
 subjectKeyIdentifier = hash
 
 [ subject_alt_names ]
-DNS.1 = *.<%= domain %>
-DNS.2 = <%= domain %>
+DNS.1 = <%= domain %>
+DNS.2 = *.<%= domain %>

--- a/openssl-configurations/domain-certificates.conf
+++ b/openssl-configurations/domain-certificates.conf
@@ -35,5 +35,5 @@ extendedKeyUsage = serverAuth
 subjectAltName = @subject_alt_names
 
 [ subject_alt_names ]
-DNS.1 = *.<%= domain %>
-DNS.2 = <%= domain %>
+DNS.1 = <%= domain %>
+DNS.2 = *.<%= domain %>


### PR DESCRIPTION
Getting error `SSL_ERROR_BAD_CERT_DOMAIN` in Firefox on Windows.

For whatever reason, if the wildcard domain is the first domain in the list, Firefox will generate the error, even though the necessary host is, in fact, in the list.  Putting the domain that matches the CN first seems to work, and Firefox trusts the certificate. 🤷‍♂ 