### PR TITLE
Fix unquoted filepaths

### DIFF
--- a/src/platforms/linux.ts
+++ b/src/platforms/linux.ts
@@ -32,7 +32,7 @@ export default class LinuxPlatform implements Platform {
 
     debug('Adding devcert root CA to Linux system-wide trust stores');
     // run(`sudo cp ${ certificatePath } /etc/ssl/certs/devcert.crt`);
-    run(`sudo cp ${ certificatePath } /usr/local/share/ca-certificates/devcert.crt`);
+    run(`sudo cp "${ certificatePath }" /usr/local/share/ca-certificates/devcert.crt`);
     // run(`sudo bash -c "cat ${ certificatePath } >> /etc/ssl/certs/ca-certificates.crt"`);
     run(`sudo update-ca-certificates`);
 
@@ -76,7 +76,7 @@ export default class LinuxPlatform implements Platform {
   }
 
   async readProtectedFile(filepath: string) {
-    return (await run(`sudo cat ${filepath}`)).toString().trim();
+    return (await run(`sudo cat "${filepath}"`)).toString().trim();
   }
 
   async writeProtectedFile(filepath: string, contents: string) {

--- a/src/platforms/shared.ts
+++ b/src/platforms/shared.ts
@@ -23,11 +23,11 @@ export async function addCertificateToNSSCertDB(nssDirGlob: string, certPath: st
     debug(`checking to see if ${ potentialNSSDBDir } is a valid NSS database directory`);
     if (exists(path.join(potentialNSSDBDir, 'cert8.db'))) {
       debug(`Found legacy NSS database in ${ potentialNSSDBDir }, adding certificate ...`)
-      run(`${ certutilPath } -A -d "${ potentialNSSDBDir }" -t 'C,,' -i ${ certPath } -n devcert`);
+      run(`${ certutilPath } -A -d "${ potentialNSSDBDir }" -t 'C,,' -i "${ certPath }" -n devcert`);
     }
     if (exists(path.join(potentialNSSDBDir, 'cert9.db'))) {
       debug(`Found modern NSS database in ${ potentialNSSDBDir }, adding certificate ...`)
-      run(`${ certutilPath } -A -d "sql:${ potentialNSSDBDir }" -t 'C,,' -i ${ certPath } -n devcert`);
+      run(`${ certutilPath } -A -d "sql:${ potentialNSSDBDir }" -t 'C,,' -i "${ certPath }" -n devcert`);
     }
   });
   debug(`finished scanning & installing certificate in NSS databases in ${ nssDirGlob }`);

--- a/src/platforms/win32.ts
+++ b/src/platforms/win32.ts
@@ -27,7 +27,7 @@ export default class WindowsPlatform implements Platform {
     // IE, Chrome, system utils
     debug('adding devcert root to Windows OS trust store')
     try {
-      run(`certutil -addstore -user root ${ certificatePath }`);
+      run(`certutil -addstore -user root "${ certificatePath }"`);
     } catch (e) {
       e.output.map((buffer: Buffer) => {
         if (buffer) {


### PR DESCRIPTION
Pretty much guaranteed that there will be issues anytime a file path is passed to a shell command unquoted.  If the path contains spaces, then the command will fail.  See gatsbyjs/gatsby#16212 (on an older version)

These might be infrequent, but they happen.  Most of them have already been fixed since the upgrade to v1.0.0.  Here's a couple more.