### PR TITLE
Fixes expiration date issues on MacOS

### DIFF
--- a/src/certificate-authority.ts
+++ b/src/certificate-authority.ts
@@ -44,7 +44,7 @@ export default async function installCertificateAuthority(options: Options = {})
   generateKey(rootKeyPath);
 
   debug(`Generating a CA certificate`);
-  openssl(`req -new -x509 -config "${ caSelfSignConfig }" -key "${ rootKeyPath }" -out "${ rootCertPath }" -days 7000`);
+  openssl(`req -new -x509 -config "${ caSelfSignConfig }" -key "${ rootKeyPath }" -out "${ rootCertPath }" -days 825`);
 
   debug('Saving certificate authority credentials');
   await saveCertificateAuthorityCredentials(rootKeyPath, rootCertPath);

--- a/src/certificates.ts
+++ b/src/certificates.ts
@@ -33,7 +33,7 @@ export default async function generateDomainCertificate(domain: string): Promise
 
   await withCertificateAuthorityCredentials(({ caKeyPath, caCertPath }) => {
     withDomainCertificateConfig(domain, (domainCertConfigPath) => {
-      openssl(`ca -config "${ domainCertConfigPath }" -in "${ csrFile }" -out "${ domainCertPath }" -keyfile "${ caKeyPath }" -cert "${ caCertPath }" -days 7000 -batch`)
+      openssl(`ca -config "${ domainCertConfigPath }" -in "${ csrFile }" -out "${ domainCertPath }" -keyfile "${ caKeyPath }" -cert "${ caCertPath }" -days 825 -batch`)
     });
   });
 }


### PR DESCRIPTION
Due to security reasons, MacOS Catalina will now reject certificates with an expiration date longer than 825 days.  That's over 2 years, so for a development certificate, it seems like a reasonable timeframe.

IMO, any work to extend it past that date should be focused more on renewal than extending the expiration.  Until that kind of work is done, people can also just wipe out their certificates and build new ones.  It's not too hard, and only having to do it every two years isn't really that bad.

On the other hand, keeping the expiration at 7000 days makes the generated certificates completely useless for Mac users.

Fixes #39,

Conflicts with #41.  -> [This change will need to happen to merge both](https://github.com/davewasmer/devcert/pull/41/files#diff-dd7919ef939d9fd2efac5643c9e56d9bL47-R46)