### PR TITLE
fix: Remove protection on CA file after upgrade

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -56,6 +56,23 @@ export const rootCADir = configPath('certificate-authority');
 export const rootCAKeyPath = configPath('certificate-authority', 'private-key.key');
 export const rootCACertPath = configPath('certificate-authority', 'certificate.cert');
 
-mkdirp(configDir);
-mkdirp(domainsDir);
-mkdirp(rootCADir);
+
+
+// Exposed for uninstallation purposes.
+export function getLegacyConfigDir(): string {
+  if (isWindows && process.env.LOCALAPPDATA) {
+    return path.join(process.env.LOCALAPPDATA, 'devcert', 'config');
+  } else {
+    let uid = process.getuid && process.getuid();
+    let userHome = (isLinux && uid === 0) ? path.resolve('/usr/local/share') : require('os').homedir();
+    return path.join(userHome, '.config', 'devcert');
+  }
+}
+
+export function ensureConfigDirs() {
+  mkdirp(configDir);
+  mkdirp(domainsDir);
+  mkdirp(rootCADir);
+}
+
+ensureConfigDirs();

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,9 +12,10 @@ import {
   rootCACertPath
 } from './constants';
 import currentPlatform from './platforms';
-import installCertificateAuthority, { ensureCACertReadable } from './certificate-authority';
+import installCertificateAuthority, { ensureCACertReadable, uninstall } from './certificate-authority';
 import generateDomainCertificate from './certificates';
 import UI, { UserInterface } from './user-interface';
+export { uninstall };
 
 const debug = createDebug('devcert');
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import {
   rootCACertPath
 } from './constants';
 import currentPlatform from './platforms';
-import installCertificateAuthority from './certificate-authority';
+import installCertificateAuthority, { ensureCACertReadable } from './certificate-authority';
 import generateDomainCertificate from './certificates';
 import UI, { UserInterface } from './user-interface';
 
@@ -84,6 +84,9 @@ export async function certificateFor<O extends Options>(domain: string, options:
   if (!exists(rootCAKeyPath)) {
     debug('Root CA is not installed yet, so it must be our first run. Installing root CA ...');
     await installCertificateAuthority(options);
+  } else if (options.getCaBuffer || options.getCaPath) {
+    debug('Root CA is not readable, but it probably is because an earlier version of devcert locked it. Trying to fix...');
+    await ensureCACertReadable(options);
   }
 
   if (!exists(pathForDomain(domain, `certificate.crt`))) {

--- a/src/platforms/darwin.ts
+++ b/src/platforms/darwin.ts
@@ -62,6 +62,10 @@ export default class MacOSPlatform implements Platform {
       run(`echo '\n127.0.0.1 ${ domain }' | sudo tee -a "${ this.HOST_FILE_PATH }" > /dev/null`);
     }
   }
+  
+  async deleteProtectedFile(filepath: string) {
+    await run(`sudo rm "${filepath}"`);
+  }
 
   async readProtectedFile(filepath: string) {
     return (await run(`sudo cat "${filepath}"`)).toString().trim();

--- a/src/platforms/darwin.ts
+++ b/src/platforms/darwin.ts
@@ -4,11 +4,12 @@ import createDebug from 'debug';
 import { sync as commandExists } from 'command-exists';
 import { run } from '../utils';
 import { Options } from '../index';
-import { addCertificateToNSSCertDB, openCertificateInFirefox, closeFirefox } from './shared';
+import { addCertificateToNSSCertDB, assertNotTouchingFiles, openCertificateInFirefox, closeFirefox, removeCertificateFromNSSCertDB } from './shared';
 import { Platform } from '.';
 
 const debug = createDebug('devcert:platforms:macos');
 
+const getCertUtilPath = () => path.join(run('brew --prefix nss').toString().trim(), 'bin', 'certutil');
 
 export default class MacOSPlatform implements Platform {
 
@@ -48,11 +49,23 @@ export default class MacOSPlatform implements Platform {
           return await openCertificateInFirefox(this.FIREFOX_BIN_PATH, certificatePath);
         }
       }
-      let certutilPath = path.join(run('brew --prefix nss').toString().trim(), 'bin', 'certutil');
       await closeFirefox();
-      await addCertificateToNSSCertDB(this.FIREFOX_NSS_DIR, certificatePath, certutilPath);
+      await addCertificateToNSSCertDB(this.FIREFOX_NSS_DIR, certificatePath, getCertUtilPath());
     } else {
       debug('Firefox does not appear to be installed, skipping Firefox-specific steps...');
+    }
+  }
+  
+  removeFromTrustStores(certificatePath: string) {
+    debug('Removing devcert root CA from macOS system keychain');
+    try {
+      run(`sudo security remove-trusted-cert -d "${ certificatePath }"`);
+    } catch(e) {
+      debug(`failed to remove ${ certificatePath } from macOS cert store, continuing. ${ e.toString() }`);
+    }
+    if (this.isFirefoxInstalled() && this.isNSSInstalled()) {
+      debug('Firefox install and certutil install detected. Trying to remove root CA from Firefox NSS databases');
+      removeCertificateFromNSSCertDB(this.FIREFOX_NSS_DIR, certificatePath, getCertUtilPath());
     }
   }
 
@@ -63,15 +76,18 @@ export default class MacOSPlatform implements Platform {
     }
   }
   
-  async deleteProtectedFile(filepath: string) {
-    await run(`sudo rm "${filepath}"`);
+  deleteProtectedFiles(filepath: string) {
+    assertNotTouchingFiles(filepath, 'delete');
+    run(`sudo rm -rf "${filepath}"`);
   }
 
   async readProtectedFile(filepath: string) {
+    assertNotTouchingFiles(filepath, 'read');
     return (await run(`sudo cat "${filepath}"`)).toString().trim();
   }
 
   async writeProtectedFile(filepath: string, contents: string) {
+    assertNotTouchingFiles(filepath, 'write');
     if (exists(filepath)) {
       await run(`sudo rm "${filepath}"`);
     }

--- a/src/platforms/index.ts
+++ b/src/platforms/index.ts
@@ -4,6 +4,7 @@ import { Options } from '../index';
 export interface Platform {
    addToTrustStores(certificatePath: string, options?: Options): Promise<void>;
    addDomainToHostFileIfMissing(domain: string): Promise<void>;
+   deleteProtectedFile(filepath: string): Promise<void>;
    readProtectedFile(filepath: string): Promise<string>;
    writeProtectedFile(filepath: string, contents: string): Promise<void>;
 }

--- a/src/platforms/index.ts
+++ b/src/platforms/index.ts
@@ -3,8 +3,9 @@ import { Options } from '../index';
 
 export interface Platform {
    addToTrustStores(certificatePath: string, options?: Options): Promise<void>;
+   removeFromTrustStores(certificatePath: string): void;
    addDomainToHostFileIfMissing(domain: string): Promise<void>;
-   deleteProtectedFile(filepath: string): Promise<void>;
+   deleteProtectedFiles(filepath: string): void;
    readProtectedFile(filepath: string): Promise<string>;
    writeProtectedFile(filepath: string, contents: string): Promise<void>;
 }

--- a/src/platforms/linux.ts
+++ b/src/platforms/linux.ts
@@ -75,6 +75,10 @@ export default class LinuxPlatform implements Platform {
     }
   }
 
+  async deleteProtectedFile(filepath: string) {
+    await run(`sudo rm ${filepath}"`);
+  }
+
   async readProtectedFile(filepath: string) {
     return (await run(`sudo cat "${filepath}"`)).toString().trim();
   }

--- a/src/platforms/linux.ts
+++ b/src/platforms/linux.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import { existsSync as exists, readFileSync as read, writeFileSync as writeFile } from 'fs';
 import createDebug from 'debug';
 import { sync as commandExists } from 'command-exists';
-import { addCertificateToNSSCertDB, openCertificateInFirefox, closeFirefox } from './shared';
+import { addCertificateToNSSCertDB, assertNotTouchingFiles, openCertificateInFirefox, closeFirefox, removeCertificateFromNSSCertDB } from './shared';
 import { run } from '../utils';
 import { Options } from '../index';
 import UI from '../user-interface';
@@ -67,6 +67,23 @@ export default class LinuxPlatform implements Platform {
       debug('Chrome does not appear to be installed, skipping Chrome-specific steps...');
     }
   }
+  
+  removeFromTrustStores(certificatePath: string) {
+    try {
+      run(`sudo rm /usr/local/share/ca-certificates/devcert.crt`);
+      run(`sudo update-ca-certificates`); 
+    } catch (e) {
+      debug(`failed to remove ${ certificatePath } from /usr/local/share/ca-certificates, continuing. ${ e.toString() }`);
+    }
+    if (commandExists('certutil')) {
+      if (this.isFirefoxInstalled()) {
+        removeCertificateFromNSSCertDB(this.FIREFOX_NSS_DIR, certificatePath, 'certutil');
+      }
+      if (this.isChromeInstalled()) {
+        removeCertificateFromNSSCertDB(this.CHROME_NSS_DIR, certificatePath, 'certutil');
+      }
+    }
+  }
 
   async addDomainToHostFileIfMissing(domain: string) {
     let hostsFileContents = read(this.HOST_FILE_PATH, 'utf8');
@@ -75,15 +92,18 @@ export default class LinuxPlatform implements Platform {
     }
   }
 
-  async deleteProtectedFile(filepath: string) {
-    await run(`sudo rm ${filepath}"`);
+  deleteProtectedFiles(filepath: string) {
+    assertNotTouchingFiles(filepath, 'delete');
+    run(`sudo rm -rf "${filepath}"`);
   }
 
   async readProtectedFile(filepath: string) {
+    assertNotTouchingFiles(filepath, 'read');
     return (await run(`sudo cat "${filepath}"`)).toString().trim();
   }
 
   async writeProtectedFile(filepath: string, contents: string) {
+    assertNotTouchingFiles(filepath, 'write');
     if (exists(filepath)) {
       await run(`sudo rm "${filepath}"`);
     }
@@ -91,7 +111,6 @@ export default class LinuxPlatform implements Platform {
     await run(`sudo chown 0 "${filepath}"`);
     await run(`sudo chmod 600 "${filepath}"`);
   }
-
 
   private isFirefoxInstalled() {
     return exists(this.FIREFOX_BIN_PATH);

--- a/src/platforms/win32.ts
+++ b/src/platforms/win32.ts
@@ -1,6 +1,6 @@
 import createDebug from 'debug';
 import crypto from 'crypto';
-import { writeFileSync as write, readFileSync as read } from 'fs';
+import { writeFileSync as write, readFileSync as read, unlinkSync as unlink } from 'fs';
 import { Options } from '../index';
 import { openCertificateInFirefox } from './shared';
 import { Platform } from '.';
@@ -49,6 +49,10 @@ export default class WindowsPlatform implements Platform {
     if (!hostsFileContents.includes(domain)) {
       await sudo(`echo 127.0.0.1  ${ domain } >> ${ this.HOST_FILE_PATH }`);
     }
+  }
+  
+  async deleteProtectedFile(filepath: string) {
+    unlink(filepath);
   }
 
   async readProtectedFile(filepath: string): Promise<string> {

--- a/src/platforms/win32.ts
+++ b/src/platforms/win32.ts
@@ -48,6 +48,7 @@ export default class WindowsPlatform implements Platform {
   removeFromTrustStores(certificatePath: string) {
     debug('removing devcert root from Windows OS trust store');
     try {
+      console.warn('Removing old certificates from trust stores. You may be prompted to grant permission for this. It\'s safe to delete old devcert certificates.');
       run(`certutil -delstore -user root devcert`);
     } catch (e) {
       debug(`failed to remove ${ certificatePath } from Windows OS trust store, continuing. ${ e.toString() }`)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,9 +4,7 @@ import createDebug from 'debug';
 import path from 'path';
 import sudoPrompt from 'sudo-prompt';
 
-import {
-  configPath,
-} from './constants';
+import { configPath } from './constants';
 
 const debug = createDebug('devcert:util');
 


### PR DESCRIPTION
Since #41 merged, the master branch bombs out when trying to use the new `getCaPath` and `getCaBuffer` options on a CA installed by a previous version of devcert, because they are unreadable files! This addition makes them readable after upgrade.

@Js-Brecht if you wanna take a look at this, I'd welcome it, but if you're busy, I'll regress and merge it myself so I can release 1.1.0 for you tomorrow.