### PR TITLE
Fix valid domain regex

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,7 +6,8 @@ import applicationConfigPath = require('application-config-path');
 import eol from 'eol';
 import { mktmp } from './utils';
 
-export const VALID_DOMAIN = /(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]/;
+// Based on https://gist.github.com/dperini/729294
+export const VALID_DOMAIN = /^(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z0-9\u00a1-\uffff][a-z0-9\u00a1-\uffff_-]{0,62})?[a-z0-9\u00a1-\uffff]\.?)+(?:[a-z\u00a1-\uffff]{2,}\.?))$/i;
 
 // Platform shortcuts
 export const isMac = process.platform === 'darwin';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,8 +6,7 @@ import applicationConfigPath = require('application-config-path');
 import eol from 'eol';
 import { mktmp } from './utils';
 
-// Based on https://gist.github.com/dperini/729294
-export const VALID_DOMAIN = /^(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z0-9\u00a1-\uffff][a-z0-9\u00a1-\uffff_-]{0,62})?[a-z0-9\u00a1-\uffff]\.?)+(?:[a-z\u00a1-\uffff]{2,}\.?))$/i;
+export const VALID_DOMAIN = /(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.?)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]/i;
 
 // Platform shortcuts
 export const isMac = process.platform === 'darwin';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,6 +6,7 @@ import applicationConfigPath = require('application-config-path');
 import eol from 'eol';
 import { mktmp } from './utils';
 
+export const VALID_IP = /(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}/;
 export const VALID_DOMAIN = /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.?)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$/i;
 
 // Platform shortcuts

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,7 +6,7 @@ import applicationConfigPath = require('application-config-path');
 import eol from 'eol';
 import { mktmp } from './utils';
 
-export const VALID_DOMAIN = /(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.?)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]/i;
+export const VALID_DOMAIN = /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.?)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$/i;
 
 // Platform shortcuts
 export const isMac = process.platform === 'darwin';

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,7 @@ type IReturnData<O extends Options = {}> = (IDomainData) & (IReturnCa<O>) & (IRe
 export async function certificateFor<O extends Options>(domain: string, options: O = {} as O): Promise<IReturnData<O>> {
   if (VALID_IP.test(domain)) {
     throw new Error('IP addresses are not supported currently');
+  }
   if (!VALID_DOMAIN.test(domain)) {
     throw new Error(`"${domain}" is not a valid domain name.`);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,8 @@ import {
   domainsDir,
   rootCAKeyPath,
   rootCACertPath,
-  VALID_DOMAIN
+  VALID_DOMAIN,
+  VALID_IP
 } from './constants';
 import currentPlatform from './platforms';
 import installCertificateAuthority, { ensureCACertReadable, uninstall } from './certificate-authority';
@@ -66,6 +67,8 @@ type IReturnData<O extends Options = {}> = (IDomainData) & (IReturnCa<O>) & (IRe
  * as { caPath: string }
  */
 export async function certificateFor<O extends Options>(domain: string, options: O = {} as O): Promise<IReturnData<O>> {
+  if (VALID_IP.test(domain)) {
+    throw new Error('IP addresses are not supported currently');
   if (!VALID_DOMAIN.test(domain)) {
     throw new Error(`"${domain}" is not a valid domain name.`);
   }


### PR DESCRIPTION
Fixes #56 

Based on https://gist.github.com/dperini/729294

Stripped the following checks from the above gist regex:

- protocol (http, ftp)
- short syntax (//)
- basic auth (user:pass)
- requirement for TLD (\. made optional)
- port number (:port)
- resource path (/path, #resource-path)

Should now work for IPs, `localhost`, and valid domains


**UPDATE:** Since the generated certificates don't support IP addresses, I reverted the change and just simply modified the Regex to handle `localhost` and make it case-insensitive.

/cc @Js-Brecht 