### PR TITLE
Move @types to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,18 +5,10 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "devcert",
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "@types/configstore": "^2.1.1",
-        "@types/debug": "^0.0.30",
-        "@types/get-port": "^3.2.0",
-        "@types/glob": "^5.0.34",
-        "@types/lodash": "^4.14.92",
-        "@types/mkdirp": "^0.5.2",
-        "@types/node": "^8.5.7",
-        "@types/rimraf": "^2.0.2",
-        "@types/tmp": "^0.0.33",
         "application-config-path": "^0.1.0",
         "command-exists": "^1.2.4",
         "debug": "^3.1.0",
@@ -32,6 +24,14 @@
         "tslib": "^1.10.0"
       },
       "devDependencies": {
+        "@types/debug": "^0.0.30",
+        "@types/get-port": "^3.2.0",
+        "@types/glob": "^5.0.34",
+        "@types/lodash": "^4.14.92",
+        "@types/mkdirp": "^0.5.2",
+        "@types/node": "^8.5.7",
+        "@types/rimraf": "^2.0.2",
+        "@types/tmp": "^0.0.33",
         "standard-version": "^8.0.1",
         "typescript": "4.3.2"
       }
@@ -62,30 +62,29 @@
         "js-tokens": "^4.0.0"
       }
     },
-    "node_modules/@types/configstore": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@types/configstore/-/configstore-2.1.1.tgz",
-      "integrity": "sha1-zR6FU2M60xhcPy8jns/10mQ+krY="
-    },
     "node_modules/@types/debug": {
       "version": "0.0.30",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.30.tgz",
-      "integrity": "sha512-orGL5LXERPYsLov6CWs3Fh6203+dXzJkR7OnddIr2514Hsecwc8xRpzCapshBbKFImCsvS/mk6+FWiN5LyZJAQ=="
+      "integrity": "sha512-orGL5LXERPYsLov6CWs3Fh6203+dXzJkR7OnddIr2514Hsecwc8xRpzCapshBbKFImCsvS/mk6+FWiN5LyZJAQ==",
+      "dev": true
     },
     "node_modules/@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+      "dev": true
     },
     "node_modules/@types/get-port": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@types/get-port/-/get-port-3.2.0.tgz",
-      "integrity": "sha512-TiNg8R1kjDde5Pub9F9vCwZA/BNW9HeXP5b9j7Qucqncy/McfPZ6xze/EyBdXS5FhMIGN6Fx3vg75l5KHy3V1Q=="
+      "integrity": "sha512-TiNg8R1kjDde5Pub9F9vCwZA/BNW9HeXP5b9j7Qucqncy/McfPZ6xze/EyBdXS5FhMIGN6Fx3vg75l5KHy3V1Q==",
+      "dev": true
     },
     "node_modules/@types/glob": {
       "version": "5.0.36",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.36.tgz",
       "integrity": "sha512-KEzSKuP2+3oOjYYjujue6Z3Yqis5HKA1BsIC+jZ1v3lrRNdsqyNNtX0rQf6LSuI4DJJ2z5UV//zBZCcvM0xikg==",
+      "dev": true,
       "dependencies": {
         "@types/events": "*",
         "@types/minimatch": "*",
@@ -95,12 +94,14 @@
     "node_modules/@types/lodash": {
       "version": "4.14.170",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.170.tgz",
-      "integrity": "sha512-bpcvu/MKHHeYX+qeEN8GE7DIravODWdACVA1ctevD8CN24RhPZIKMn9ntfAsrvLfSX3cR5RrBKAbYm9bGs0A+Q=="
+      "integrity": "sha512-bpcvu/MKHHeYX+qeEN8GE7DIravODWdACVA1ctevD8CN24RhPZIKMn9ntfAsrvLfSX3cR5RrBKAbYm9bGs0A+Q==",
+      "dev": true
     },
     "node_modules/@types/minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA=="
+      "integrity": "sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA==",
+      "dev": true
     },
     "node_modules/@types/minimist": {
       "version": "1.2.1",
@@ -112,6 +113,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.5.2.tgz",
       "integrity": "sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -119,7 +121,8 @@
     "node_modules/@types/node": {
       "version": "8.10.66",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
-      "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw=="
+      "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==",
+      "dev": true
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.0",
@@ -131,6 +134,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-2.0.4.tgz",
       "integrity": "sha512-8gBudvllD2A/c0CcEX/BivIDorHFt5UI5m46TsNj8DjWCCTTZT74kEe4g+QsY7P/B9WdO98d82zZgXO/RQzu2Q==",
+      "dev": true,
       "dependencies": {
         "@types/glob": "*",
         "@types/node": "*"
@@ -139,7 +143,8 @@
     "node_modules/@types/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha1-EHPEvIJHVK49EM+riKsCN7qWTk0="
+      "integrity": "sha1-EHPEvIJHVK49EM+riKsCN7qWTk0=",
+      "dev": true
     },
     "node_modules/add-stream": {
       "version": "1.0.0",
@@ -3233,30 +3238,29 @@
         "js-tokens": "^4.0.0"
       }
     },
-    "@types/configstore": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@types/configstore/-/configstore-2.1.1.tgz",
-      "integrity": "sha1-zR6FU2M60xhcPy8jns/10mQ+krY="
-    },
     "@types/debug": {
       "version": "0.0.30",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.30.tgz",
-      "integrity": "sha512-orGL5LXERPYsLov6CWs3Fh6203+dXzJkR7OnddIr2514Hsecwc8xRpzCapshBbKFImCsvS/mk6+FWiN5LyZJAQ=="
+      "integrity": "sha512-orGL5LXERPYsLov6CWs3Fh6203+dXzJkR7OnddIr2514Hsecwc8xRpzCapshBbKFImCsvS/mk6+FWiN5LyZJAQ==",
+      "dev": true
     },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+      "dev": true
     },
     "@types/get-port": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@types/get-port/-/get-port-3.2.0.tgz",
-      "integrity": "sha512-TiNg8R1kjDde5Pub9F9vCwZA/BNW9HeXP5b9j7Qucqncy/McfPZ6xze/EyBdXS5FhMIGN6Fx3vg75l5KHy3V1Q=="
+      "integrity": "sha512-TiNg8R1kjDde5Pub9F9vCwZA/BNW9HeXP5b9j7Qucqncy/McfPZ6xze/EyBdXS5FhMIGN6Fx3vg75l5KHy3V1Q==",
+      "dev": true
     },
     "@types/glob": {
       "version": "5.0.36",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.36.tgz",
       "integrity": "sha512-KEzSKuP2+3oOjYYjujue6Z3Yqis5HKA1BsIC+jZ1v3lrRNdsqyNNtX0rQf6LSuI4DJJ2z5UV//zBZCcvM0xikg==",
+      "dev": true,
       "requires": {
         "@types/events": "*",
         "@types/minimatch": "*",
@@ -3266,12 +3270,14 @@
     "@types/lodash": {
       "version": "4.14.170",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.170.tgz",
-      "integrity": "sha512-bpcvu/MKHHeYX+qeEN8GE7DIravODWdACVA1ctevD8CN24RhPZIKMn9ntfAsrvLfSX3cR5RrBKAbYm9bGs0A+Q=="
+      "integrity": "sha512-bpcvu/MKHHeYX+qeEN8GE7DIravODWdACVA1ctevD8CN24RhPZIKMn9ntfAsrvLfSX3cR5RrBKAbYm9bGs0A+Q==",
+      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA=="
+      "integrity": "sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA==",
+      "dev": true
     },
     "@types/minimist": {
       "version": "1.2.1",
@@ -3283,6 +3289,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.5.2.tgz",
       "integrity": "sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -3290,7 +3297,8 @@
     "@types/node": {
       "version": "8.10.66",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
-      "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw=="
+      "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==",
+      "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -3302,6 +3310,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-2.0.4.tgz",
       "integrity": "sha512-8gBudvllD2A/c0CcEX/BivIDorHFt5UI5m46TsNj8DjWCCTTZT74kEe4g+QsY7P/B9WdO98d82zZgXO/RQzu2Q==",
+      "dev": true,
       "requires": {
         "@types/glob": "*",
         "@types/node": "*"
@@ -3310,7 +3319,8 @@
     "@types/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha1-EHPEvIJHVK49EM+riKsCN7qWTk0="
+      "integrity": "sha1-EHPEvIJHVK49EM+riKsCN7qWTk0=",
+      "dev": true
     },
     "add-stream": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -26,11 +26,6 @@
   },
   "homepage": "https://github.com/davewasmer/devcert#readme",
   "devDependencies": {
-    "standard-version": "^8.0.1",
-    "typescript": "4.3.2"
-  },
-  "dependencies": {
-    "@types/configstore": "^2.1.1",
     "@types/debug": "^0.0.30",
     "@types/get-port": "^3.2.0",
     "@types/glob": "^5.0.34",
@@ -39,6 +34,10 @@
     "@types/node": "^8.5.7",
     "@types/rimraf": "^2.0.2",
     "@types/tmp": "^0.0.33",
+    "standard-version": "^8.0.1",
+    "typescript": "4.3.2"
+  },
+  "dependencies": {
     "application-config-path": "^0.1.0",
     "command-exists": "^1.2.4",
     "debug": "^3.1.0",


### PR DESCRIPTION
Resolves #32

Closes #66

`@types` should be placed in `devDependencies` as they're not required at runtime and are only relevant when developing on `devcert`