### PR TITLE
Allow IP address as domains

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1475,9 +1475,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -3571,9 +3571,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devcert",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Generate trusted local SSL/TLS certificates for local SSL development",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,10 +1,11 @@
-import path from 'path';
-import { unlinkSync as rm, writeFileSync as writeFile, readFileSync as readFile } from 'fs';
-import { sync as mkdirp } from 'mkdirp';
-import { template as makeTemplate } from 'lodash';
-import applicationConfigPath = require('application-config-path');
 import eol from 'eol';
-import {mktmp, numericHash} from './utils';
+import { readFileSync as readFile, unlinkSync as rm, writeFileSync as writeFile } from 'fs';
+import { template as makeTemplate } from 'lodash';
+import { sync as mkdirp } from 'mkdirp';
+import { isIP } from 'net';
+import path from 'path';
+import { mktmp, numericHash } from './utils';
+import applicationConfigPath = require('application-config-path');
 
 // Platform shortcuts
 export const isMac = process.platform === 'darwin';
@@ -52,10 +53,12 @@ export const caSelfSignConfig = path.join(__dirname, '../openssl-configurations/
 function generateSubjectAltNames(domains: string[]): string {
   return domains
     .reduce((dnsEntries, domain) =>
-      dnsEntries.concat([
-        `DNS.${dnsEntries.length + 1} = ${domain}`,
-        `DNS.${dnsEntries.length + 2} = *.${domain}`,
-      ]), [] as string[])
+      isIP(domain) > 0
+        ? dnsEntries.concat(`DNS.${dnsEntries.length + 1} = ${domain}`)
+        : dnsEntries.concat([
+          `DNS.${dnsEntries.length + 1} = ${domain}`,
+          `DNS.${dnsEntries.length + 2} = *.${domain}`,
+        ]), [] as string[])
     .join("\r\n");
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -54,7 +54,7 @@ function generateSubjectAltNames(domains: string[]): string {
   return domains
     .reduce((dnsEntries, domain) =>
       isIP(domain) > 0
-        ? dnsEntries.concat(`DNS.${dnsEntries.length + 1} = ${domain}`)
+        ? dnsEntries.concat(`IP.${dnsEntries.length + 1} = ${domain}`)
         : dnsEntries.concat([
           `DNS.${dnsEntries.length + 1} = ${domain}`,
           `DNS.${dnsEntries.length + 2} = *.${domain}`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,17 @@
-import { readFileSync as readFile, readdirSync as readdir, existsSync as exists } from 'fs';
-import createDebug from 'debug';
 import { sync as commandExists } from 'command-exists';
+import createDebug from 'debug';
+import { existsSync as exists, readdirSync as readdir, readFileSync as readFile } from 'fs';
+import isValidDomain from 'is-valid-domain';
+import { isIP } from 'net';
 import rimraf from 'rimraf';
-import {
-  isMac,
-  isLinux,
-  isWindows,
-  pathForDomain,
-  getStableDomainPath,
-  domainsDir,
-  rootCAKeyPath,
-  rootCACertPath,
-} from './constants';
-import currentPlatform from './platforms';
 import installCertificateAuthority, { ensureCACertReadable, uninstall } from './certificate-authority';
 import generateDomainCertificate from './certificates';
+import {
+  domainsDir, getStableDomainPath, isLinux, isMac, isWindows,
+  pathForDomain, rootCACertPath, rootCAKeyPath
+} from './constants';
+import currentPlatform from './platforms';
 import UI, { UserInterface } from './user-interface';
-import isValidDomain from 'is-valid-domain';
 export { uninstall };
 
 const debug = createDebug('devcert');
@@ -69,7 +64,7 @@ type IReturnData<O extends Options = {}> = (IDomainData) & (IReturnCa<O>) & (IRe
 export async function certificateFor<O extends Options>(requestedDomains: string | string[], options: O = {} as O): Promise<IReturnData<O>> {
   const domains = Array.isArray(requestedDomains) ? requestedDomains : [requestedDomains];
   domains.forEach((domain) => {
-    if (domain !== "localhost" && !isValidDomain(domain, { subdomain: true, wildcard: false, allowUnicode: true, topLevel: false })) {
+    if (domain !== "localhost" && !isValidDomain(domain, { subdomain: true, wildcard: false, allowUnicode: true, topLevel: false }) && isIP(domain) === 0) {
       throw new Error(`"${domain}" is not a valid domain name.`);
     }
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ export async function certificateFor<O extends Options>(requestedDomains: string
   const domains = Array.isArray(requestedDomains) ? requestedDomains : [requestedDomains];
   domains.forEach((domain) => {
     if (domain !== "localhost" && !isValidDomain(domain, { subdomain: true, wildcard: false, allowUnicode: true, topLevel: false }) && isIP(domain) === 0) {
-      throw new Error(`"${domain}" is not a valid domain name.`);
+      throw new Error(`"${domain}" is not a domain name or IP address.`);
     }
   });
 


### PR DESCRIPTION
This PR allow users to also use IP addresses as domain options while generating certificates.

Eg.:
```ts
import * as devcert from 'devcert'

const ssl = await devcert.certificateFor([
  'somedomain.local',
  'localhost',
  '192.168.1.2',
  '127.0.0.1'
])
```

PS.: It would be much less changes, but my VS Code has the `organizeImports` feature enable, so when I saved the files it have sorted and organized the imports. If that's a problem, I can undo this before merge (if you want).

Congratulations for the great tool. 😄