### PR TITLE
Move types packages to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,6 @@
   },
   "homepage": "https://github.com/davewasmer/devcert#readme",
   "devDependencies": {
-    "standard-version": "^9.5.0",
-    "typescript": "4.3.2"
-  },
-  "dependencies": {
     "@types/configstore": "^2.1.1",
     "@types/debug": "^0.0.30",
     "@types/get-port": "^3.2.0",
@@ -39,6 +35,10 @@
     "@types/node": "^8.5.7",
     "@types/rimraf": "^2.0.2",
     "@types/tmp": "^0.0.33",
+    "standard-version": "^9.5.0",
+    "typescript": "4.3.2"
+  },
+  "dependencies": {
     "application-config-path": "^0.1.0",
     "command-exists": "^1.2.4",
     "debug": "^3.1.0",


### PR DESCRIPTION
Since these are only needed in build time, this should save some install time for users.