### PR TITLE
Fix infinite recursion in win32 readProtectedFile on decrypt failure

### DIFF
--- a/src/platforms/win32.ts
+++ b/src/platforms/win32.ts
@@ -77,7 +77,7 @@ export default class WindowsPlatform implements Platform {
       return this.decrypt(read(filepath, 'utf8'), encryptionKey);
     } catch (e) {
       // If it's a bad password, clear the cached copy and retry
-      if (e.message.indexOf('bad decrypt') >= -1) {
+      if (e.message.indexOf('bad decrypt') !== -1) {
         encryptionKey = null;
         return await this.readProtectedFile(filepath);
       }


### PR DESCRIPTION
## Summary

`src/platforms/win32.ts` line 80:

```ts
if (e.message.indexOf('bad decrypt') >= -1) {
  encryptionKey = null;
  return await this.readProtectedFile(filepath);
}
```

`indexOf` returns either `-1` (not found) or a non-negative index — both `>= -1`. The check is therefore **always true**, so every decrypt error (not just "bad decrypt") clears the cached encryption key and recurses into `readProtectedFile`.

Because the recursion is `async`, it doesn't blow the stack; the process just hangs silently awaiting a Promise that never resolves. No CPU spike, no log output, nothing for a consumer to see.

This also affects consumers that supply a non-interactive `ui.getWindowsEncryptionPassword` hook (returning the same value on each call): a wrong-password scenario becomes an infinite loop instead of failing.

## Fix

Change `>= -1` to `!== -1` so the branch only fires on actual "bad decrypt" errors. Other decrypt errors now correctly fall through to `throw e`.

## Repro

On Windows, with an existing `%LOCALAPPDATA%\devcert\certificate-authority\private-key.key` encrypted with password A, call:

```js
await devcert.certificateFor('localhost', {
  ui: { getWindowsEncryptionPassword: async () => 'B' }
})
```

Process hangs silently. With this patch, you'd hit the recursion loop only on `bad decrypt`, which is the intended branch. (Note: with a non-interactive `ui` hook, the loop still recurses since the same password is returned each time — that's a separate design issue worth thinking about, but out of scope for this fix.)

## Tracking

Closes #116.

## Workaround for downstream consumers

Until this lands and a release is cut, consumers can isolate devcert's config dir to avoid colliding with state another project wrote — e.g. by intercepting `application-config-path` in Node's require cache before requiring devcert. Avoiding the collision avoids the decrypt failure entirely.