### PR TITLE
Persist root CA only after trust-store install succeeds (fixes #118)

### DIFF
--- a/src/certificate-authority.ts
+++ b/src/certificate-authority.ts
@@ -33,23 +33,43 @@ export default async function installCertificateAuthority(options: Options = {})
   uninstall();
   ensureConfigDirs();
 
-  debug(`Making a temp working directory for files to copied in`);
-  let rootKeyPath = mktmp();
-
   debug(`Generating the OpenSSL configuration needed to setup the certificate authority`);
   seedConfigFiles();
 
+  // Generate the root key + CA cert into TEMP paths first, so a failed/declined
+  // trust-store install does not leave behind canonical files that make
+  // certificateFor's `!existsSync(rootCAKeyPath)` guard skip re-installation
+  // on subsequent runs.
+  debug(`Making a temp working directory for files to be copied in`);
+  let tmpRootKeyPath = mktmp();
+  let tmpRootCertPath = mktmp();
+
   debug(`Generating a private key`);
-  generateKey(rootKeyPath);
+  generateKey(tmpRootKeyPath);
 
   debug(`Generating a CA certificate`);
-  openssl(['req', '-new', '-x509', '-config', caSelfSignConfig, '-key', rootKeyPath, '-out', rootCACertPath, '-days', '825']);
+  openssl(['req', '-new', '-x509', '-config', caSelfSignConfig, '-key', tmpRootKeyPath, '-out', tmpRootCertPath, '-days', '825']);
 
-  debug('Saving certificate authority credentials');
-  await saveCertificateAuthorityCredentials(rootKeyPath);
-
+  // Install into the OS trust store BEFORE persisting to the canonical paths.
+  // If addToTrustStores throws (e.g. user declines the Windows Security Warning,
+  // or `sudo security add-trusted-cert` fails on macOS), the canonical files
+  // are never written and the next certificateFor() call will retry the whole
+  // install — including the user-facing prompt.
   debug(`Adding the root certificate authority to trust stores`);
-  await currentPlatform.addToTrustStores(rootCACertPath, options);
+  try {
+    await currentPlatform.addToTrustStores(tmpRootCertPath, options);
+  } catch (e) {
+    rm(tmpRootKeyPath);
+    rm(tmpRootCertPath);
+    throw e;
+  }
+
+  debug(`Persisting root CA certificate and key to their canonical paths`);
+  writeFile(rootCACertPath, readFile(tmpRootCertPath));
+  await saveCertificateAuthorityCredentials(tmpRootKeyPath);
+
+  rm(tmpRootKeyPath);
+  rm(tmpRootCertPath);
 }
 
 /**

--- a/src/platforms/win32.ts
+++ b/src/platforms/win32.ts
@@ -30,11 +30,17 @@ export default class WindowsPlatform implements Platform {
     try {
       run('certutil', ['-addstore', '-user', 'root', certificatePath]);
     } catch (e) {
-      e.output.map((buffer: Buffer) => {
-        if (buffer) {
-          console.log(buffer.toString());
-        }
-      });
+      if (e.output) {
+        e.output.map((buffer: Buffer) => {
+          if (buffer) {
+            console.log(buffer.toString());
+          }
+        });
+      }
+      // certutil non-zero exit means the user declined the Windows Security
+      // Warning, or the store is otherwise unwritable. Propagate so the caller
+      // can avoid persisting on-disk state that would block future retries.
+      throw e;
     }
     debug('adding devcert root to Firefox trust store')
     // Firefox (don't even try NSS certutil, no easy install for Windows)


### PR DESCRIPTION
Fixes #118.

## Problem

`installCertificateAuthority` writes the root CA cert + encrypted key to their canonical paths **before** attempting the trust-store install. If `addToTrustStores` fails or is declined (e.g. the Windows "Security Warning" → No), the on-disk state remains and `certificateFor`'s `!existsSync(rootCAKeyPath)` guard skips re-installation forever. The browser stays broken with `NET::ERR_CERT_AUTHORITY_INVALID` and devcert never re-prompts. See #118 for the full repro.

## Fix

1. **`src/certificate-authority.ts`**: generate the cert + key into temp paths, run `addToTrustStores` first, and write to the canonical paths only after the trust install succeeds. If it throws, clean up the temp files and propagate.
2. **`src/platforms/win32.ts`**: rethrow when `certutil -addstore` fails. The current swallow is what hides the user's "No" click from the caller — without rethrowing, the reorder in (1) doesn't help, because Windows would still report success. The Firefox open-failure tolerance is preserved (most users don't have Firefox).

I considered the alternative of leaving the swallow in place and using `certutil -verifystore -user root <fingerprint>` to detect missing-from-store after the fact. Rethrowing the underlying error is simpler, surfaces the real failure to the caller, and matches the existing macOS/Linux behavior where `run('sudo', [...])` already propagates.

## Cross-platform impact

`addToTrustStores` on all three platforms reads the cert from its path argument as a one-time input (no assumptions about the path being canonical):

- **macOS** (`security add-trusted-cert ... <path>`)
- **Linux** (`cp <path> /usr/local/share/ca-certificates/devcert.crt`)
- **Windows** (`certutil -addstore -user root <path>`)

So passing a temp path is safe everywhere. The `removeFromTrustStores` calls in `uninstall()` look up by the existing canonical path / by subject name, so the initial `uninstall()` at the top of `installCertificateAuthority` is unaffected.

## Tests

The package's `npm test` script is a stub (`echo Ha.; exit 1`) and there are no test files, so no test changes. `npm run build` passes.
